### PR TITLE
Create library app with Open Library integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,54 +1,18 @@
-# React + TypeScript + Vite
+# Municipal Library
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+This project is a small frontend application using React, Vite and TypeScript. It allows you to search for books from [Open Library](https://openlibrary.org) and display some details with data coming from Wikipedia.
 
-Currently, two official plugins are available:
+## Setup
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default tseslint.config({
-  extends: [
-    // Remove ...tseslint.configs.recommended and replace with this
-    ...tseslint.configs.recommendedTypeChecked,
-    // Alternatively, use this for stricter rules
-    ...tseslint.configs.strictTypeChecked,
-    // Optionally, add this for stylistic rules
-    ...tseslint.configs.stylisticTypeChecked,
-  ],
-  languageOptions: {
-    // other options...
-    parserOptions: {
-      project: ['./tsconfig.node.json', './tsconfig.app.json'],
-      tsconfigRootDir: import.meta.dirname,
-    },
-  },
-})
+```bash
+npm install
+npm run dev
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+Run tests with:
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
-
-export default tseslint.config({
-  plugins: {
-    // Add the react-x and react-dom plugins
-    'react-x': reactX,
-    'react-dom': reactDom,
-  },
-  rules: {
-    // other rules...
-    // Enable its recommended typescript rules
-    ...reactX.configs['recommended-typescript'].rules,
-    ...reactDom.configs.recommended.rules,
-  },
-})
+```bash
+npm test
 ```
+
+The application provides a quick search bar, an advanced search page, a list of recent changes on the home page and a book detail page showing extra information from Wikipedia.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,24 @@
-// ./App.tsx
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import Header from './components/Header';
+import Footer from './components/Footer';
+import HomePage from './pages/HomePage';
+import SearchPage from './pages/SearchPage';
+import BookPage from './pages/BookPage';
 
 function App() {
-  return <h1>Accueil</h1>;
+  return (
+    <BrowserRouter>
+      <Header />
+      <main>
+        <Routes>
+          <Route path="/" element={<HomePage />} />
+          <Route path="/search" element={<SearchPage />} />
+          <Route path="/book/:id" element={<BookPage />} />
+        </Routes>
+      </main>
+      <Footer />
+    </BrowserRouter>
+  );
 }
 
 export default App;

--- a/src/api/__tests__/openLibrary.test.ts
+++ b/src/api/__tests__/openLibrary.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect, vi } from 'vitest';
+import { searchBooks } from '../openLibrary';
+
+global.fetch = vi.fn();
+
+describe('searchBooks', () => {
+  it('returns results', async () => {
+    const mockResponse = { docs: [{ key: '/works/OL1W', title: 'Test Book' }], numFound: 1 };
+    (fetch as any).mockResolvedValue({ ok: true, json: () => Promise.resolve(mockResponse) });
+    const res = await searchBooks('test');
+    expect(res.docs[0].title).toBe('Test Book');
+  });
+});

--- a/src/api/openLibrary.ts
+++ b/src/api/openLibrary.ts
@@ -1,0 +1,34 @@
+import { SearchResponse, WorkDetail } from '../types/OpenLibrary';
+
+export async function searchBooks(query: string, page = 1): Promise<SearchResponse> {
+  const response = await fetch(`https://openlibrary.org/search.json?q=${encodeURIComponent(query)}&page=${page}`);
+  if (!response.ok) {
+    throw new Error('Failed to search books');
+  }
+  return response.json();
+}
+
+export async function advancedSearch(params: Record<string, string>): Promise<SearchResponse> {
+  const query = new URLSearchParams(params).toString();
+  const response = await fetch(`https://openlibrary.org/search.json?${query}`);
+  if (!response.ok) {
+    throw new Error('Failed to search books');
+  }
+  return response.json();
+}
+
+export async function getRecentChanges(limit = 10) {
+  const response = await fetch(`https://openlibrary.org/recentchanges.json?limit=${limit}`);
+  if (!response.ok) {
+    throw new Error('Failed to fetch recent changes');
+  }
+  return response.json();
+}
+
+export async function getWork(id: string): Promise<WorkDetail> {
+  const response = await fetch(`https://openlibrary.org/works/${id}.json`);
+  if (!response.ok) {
+    throw new Error('Failed to fetch work');
+  }
+  return response.json();
+}

--- a/src/api/wikipedia.ts
+++ b/src/api/wikipedia.ts
@@ -1,0 +1,13 @@
+export interface WikiSummary {
+  extract: string;
+  content_urls: { desktop: { page: string } };
+  thumbnail?: { source: string };
+}
+
+export async function getWikipediaSummary(title: string): Promise<WikiSummary | null> {
+  const response = await fetch(`https://en.wikipedia.org/api/rest_v1/page/summary/${encodeURIComponent(title)}`);
+  if (!response.ok) {
+    return null;
+  }
+  return response.json();
+}

--- a/src/components/Footer.module.scss
+++ b/src/components/Footer.module.scss
@@ -1,0 +1,6 @@
+.footer {
+  margin-top: 2rem;
+  padding-top: 1rem;
+  border-top: 1px solid #ccc;
+  text-align: center;
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,7 @@
+import styles from './Footer.module.scss';
+
+function Footer() {
+  return <footer className={styles.footer}>© {new Date().getFullYear()} Municipal Library</footer>;
+}
+
+export default Footer;

--- a/src/components/Header.module.scss
+++ b/src/components/Header.module.scss
@@ -1,0 +1,13 @@
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+.searchForm {
+  display: flex;
+  gap: 0.5rem;
+}
+.title {
+  font-size: 1.5rem;
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,28 @@
+import { FormEvent } from 'react';
+import { useNavigate } from 'react-router-dom';
+import styles from './Header.module.scss';
+
+function Header() {
+  const navigate = useNavigate();
+
+  const onSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const form = e.currentTarget;
+    const q = new FormData(form).get('q')?.toString().trim();
+    if (q) {
+      navigate(`/search?q=${encodeURIComponent(q)}`);
+    }
+  };
+
+  return (
+    <header className={styles.header}>
+      <h1 className={styles.title}>Municipal Library</h1>
+      <form onSubmit={onSubmit} className={styles.searchForm}>
+        <input name="q" type="text" placeholder="Search books" />
+        <button type="submit">Search</button>
+      </form>
+    </header>
+  );
+}
+
+export default Header;

--- a/src/components/SearchResults.module.scss
+++ b/src/components/SearchResults.module.scss
@@ -1,0 +1,11 @@
+.results {
+  list-style: none;
+  padding: 0;
+}
+.item {
+  margin-bottom: 0.5rem;
+}
+.author {
+  margin-left: 0.5rem;
+  color: #555;
+}

--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -1,0 +1,26 @@
+import { Link } from 'react-router-dom';
+import { SearchDoc } from '../types/OpenLibrary';
+import styles from './SearchResults.module.scss';
+
+interface Props {
+  docs: SearchDoc[];
+}
+
+function SearchResults({ docs }: Props) {
+  if (!docs.length) {
+    return <p>No results found.</p>;
+  }
+
+  return (
+    <ul className={styles.results}>
+      {docs.map((doc) => (
+        <li key={doc.key} className={styles.item}>
+          <Link to={`/book/${doc.key.replace('/works/', '')}`}>{doc.title}</Link>
+          {doc.author_name && <span className={styles.author}> by {doc.author_name.join(', ')}</span>}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export default SearchResults;

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,75 +1,21 @@
-// ./index.scss
-
 :root {
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-
   margin: 0 auto;
-  padding: 2rem;
-}
-
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
+  padding: 1rem;
+  max-width: 800px;
 }
 
 body {
   margin: 0;
-  display: flex;
-  // place-items: center;
-  // align-items: center;
-  // justify-content: center;
   min-width: 320px;
   min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
 }
 
 @media (prefers-color-scheme: light) {
   :root {
     color: #213547;
     background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
   }
 }

--- a/src/pages/BookPage.tsx
+++ b/src/pages/BookPage.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { getWork } from '../api/openLibrary';
+import { getWikipediaSummary, WikiSummary } from '../api/wikipedia';
+import { WorkDetail } from '../types/OpenLibrary';
+
+function BookPage() {
+  const { id } = useParams<{ id: string }>();
+  const [work, setWork] = useState<WorkDetail | null>(null);
+  const [wiki, setWiki] = useState<WikiSummary | null>(null);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!id) return;
+    getWork(id)
+      .then((data) => {
+        setWork(data);
+        if (data.title) {
+          getWikipediaSummary(data.title).then(setWiki);
+        }
+      })
+      .catch(() => setError('Failed to load book'));
+  }, [id]);
+
+  if (error) return <p>{error}</p>;
+  if (!work) return <p>Loading...</p>;
+
+  const description = typeof work.description === 'string' ? work.description : work.description?.value;
+
+  return (
+    <div>
+      <h2>{work.title}</h2>
+      {description && <p>{description}</p>}
+      {wiki && (
+        <div>
+          <h3>From Wikipedia</h3>
+          {wiki.thumbnail && <img src={wiki.thumbnail.source} alt={work.title} />}
+          <p>{wiki.extract}</p>
+          <a href={wiki.content_urls.desktop.page} target="_blank" rel="noreferrer">
+            Read more on Wikipedia
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default BookPage;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { getRecentChanges } from '../api/openLibrary';
+
+interface ChangeItem {
+  data?: { key?: string; title?: string };
+}
+
+function HomePage() {
+  const [changes, setChanges] = useState<ChangeItem[]>([]);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    getRecentChanges(10)
+      .then(setChanges)
+      .catch(() => setError('Failed to load recent changes'));
+  }, []);
+
+  return (
+    <div>
+      <h2>Recent Changes</h2>
+      {error && <p>{error}</p>}
+      <ul>
+        {changes.map((c, i) => {
+          const workId = c.data?.key?.replace('/works/', '');
+          if (!workId || !c.data?.title) return null;
+          return (
+            <li key={i}>
+              <Link to={`/book/${workId}`}>{c.data.title}</Link>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+export default HomePage;

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -1,0 +1,47 @@
+import { FormEvent, useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { advancedSearch, searchBooks } from '../api/openLibrary';
+import SearchResults from '../components/SearchResults';
+import { SearchDoc } from '../types/OpenLibrary';
+
+function SearchPage() {
+  const [params, setParams] = useSearchParams();
+  const [docs, setDocs] = useState<SearchDoc[]>([]);
+  const [error, setError] = useState('');
+  const q = params.get('q') || '';
+
+  useEffect(() => {
+    if (q) {
+      searchBooks(q)
+        .then((res) => setDocs(res.docs))
+        .catch(() => setError('Search failed'));
+    }
+  }, [q]);
+
+  const onSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const data = Object.fromEntries(new FormData(e.currentTarget).entries()) as Record<string, string>;
+    if (data.q) {
+      setParams(data);
+      advancedSearch(data)
+        .then((res) => setDocs(res.docs))
+        .catch(() => setError('Search failed'));
+    }
+  };
+
+  return (
+    <div>
+      <h2>Search</h2>
+      <form onSubmit={onSubmit}>
+        <input name="q" placeholder="Search" defaultValue={q} />
+        <input name="author" placeholder="Author" />
+        <input name="subject" placeholder="Subject" />
+        <button type="submit">Advanced Search</button>
+      </form>
+      {error && <p>{error}</p>}
+      <SearchResults docs={docs} />
+    </div>
+  );
+}
+
+export default SearchPage;

--- a/src/types/OpenLibrary.ts
+++ b/src/types/OpenLibrary.ts
@@ -1,0 +1,17 @@
+export interface SearchDoc {
+  key: string;
+  title: string;
+  author_name?: string[];
+}
+
+export interface SearchResponse {
+  numFound: number;
+  docs: SearchDoc[];
+}
+
+export interface WorkDetail {
+  title: string;
+  description?: string | { value: string };
+  covers?: number[];
+  subjects?: string[];
+}


### PR DESCRIPTION
## Summary
- add router and pages (home, search, book)
- implement quick search in header and advanced search page
- fetch Open Library data and Wikipedia summaries
- add basic styles
- include a unit test for search API
- update README

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68404b8fe0c88324b279e90f19df8eae